### PR TITLE
Add -trust-store-password option

### DIFF
--- a/src/axeos/verify/JarSignatureValidator.java
+++ b/src/axeos/verify/JarSignatureValidator.java
@@ -85,6 +85,8 @@ public class JarSignatureValidator {
 
 	private String trustedKeystore;
 
+	private String trustedKeystorePassword;
+
 	private boolean useOCSP;
 
 	private CertPathValidator validator;
@@ -208,7 +210,11 @@ public class JarSignatureValidator {
 				System.exit(4);
 			}
 			log.fine("Using keystore: " + f);
-			keystore.load(new FileInputStream(f), null);
+			char[] password = null;
+			if (this.trustedKeystorePassword != null) {
+				password = this.trustedKeystorePassword.toCharArray();
+			}
+			keystore.load(new FileInputStream(f), password);
 		} else if (userStore.exists()) {
 			log.fine("Using keystore: " + userStore);
 			keystore.load(new FileInputStream(userStore), null);
@@ -241,6 +247,10 @@ public class JarSignatureValidator {
 
 	public void setTrustedKeystore(String trustedKeystore) {
 		this.trustedKeystore = trustedKeystore;
+	}
+
+	public void setTrustedKeystorePassword(String trustedKeystorePassword) {
+		this.trustedKeystorePassword = trustedKeystorePassword;
 	}
 
 	public void setUseOCSP(boolean useOCSP) {

--- a/src/axeos/verify/VerifyJar.java
+++ b/src/axeos/verify/VerifyJar.java
@@ -100,6 +100,7 @@ public class VerifyJar {
 		System.err.println("   verify_jar <parameters> <jar_file>");
 		System.err.println("Parameters:");
 		System.err.println("  -trusted-keystore <file>  :  keystore with trusted CA certificates");
+		System.err.println("  -trusted-keystore-password <password>  :  password for trusted keystore");
 		System.err.println("  -ocsp  :  use OCSP for certificate verification");
 		System.err.println("  -ocsp-responder <url>  :  OCSP responder to use (default: from the signer's certificate)");
 		System.err.println("  -crl <file>  :  certificate revocation list file");
@@ -163,6 +164,8 @@ public class VerifyJar {
 				logger.setLevel(Level.ALL);
 			} else if ("-trusted-keystore".equalsIgnoreCase(par)) {
 				jv.setTrustedKeystore(args[++i]);
+			} else if ("-trusted-keystore-password".equalsIgnoreCase(par)) {
+				jv.setTrustedKeystorePassword(args[++i]);
 			} else if ("-ocsp".equalsIgnoreCase(par)) {
 				jv.setUseOCSP(true);
 			} else if ("-ocsp-responder".equalsIgnoreCase(par)) {


### PR DESCRIPTION
Java truststores in PKCS#12 format require a password.

This pull request adds the -trust-store-password to allow presenting the password in the command line.